### PR TITLE
Speedup

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,8 +5,7 @@ use nom::combinator::opt;
 use nom::multi::many0;
 
 fn is_ftext(character: u8) -> bool {
-    character >= 33 && character <= 57 ||
-    character >= 59 && character <= 126
+    character >= 33 && character != 58 && character <= 126
 }
 
 fn is_text(character: u8) -> bool {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -9,10 +9,8 @@ fn is_ftext(character: u8) -> bool {
 }
 
 fn is_text(character: u8) -> bool {
-    character >= 1 && character <= 9 ||
-    character >= 14 && character <= 127 ||
-    character == 11 ||
-    character == 12
+    character >= 1 && character <= 127 &&
+    character != 10 && character != 13
 }
 
 fn unstructured_header_value(data: &[u8]) -> IResult<&[u8], &[u8]> {


### PR DESCRIPTION
According to godbolt. It generated better code.
Also the 2 benches I run shows a improvement with the `email_parser` test.


Original code:
```
running 4 tests
test email        ... bench:      17,097 ns/iter (+/- 3,712)
test email_format ... bench:     403,548 ns/iter (+/- 26,380)
test email_parser ... bench:      75,946 ns/iter (+/- 20,761)
test mailparse    ... bench:       6,329 ns/iter (+/- 368)
```

My improvement:
```
running 4 tests
test email        ... bench:      17,911 ns/iter (+/- 3,563)
test email_format ... bench:     433,603 ns/iter (+/- 82,618)
test email_parser ... bench:      45,976 ns/iter (+/- 4,599)
test mailparse    ... bench:       6,727 ns/iter (+/- 869)
```

