### PR TITLE
Fixed a lot of parsing errors

### DIFF
--- a/email-parser/Cargo.toml
+++ b/email-parser/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["email", "mail", "mime", "parser"]
 
 [dependencies]
 textcode = {version="0.2", optional=true}
-timezone-abbreviations = { path = "../../timezone-abbreviations" }
+timezone-abbreviations = "0.1.0"
 
 [features]
 default = ["headers"]

--- a/email-parser/Cargo.toml
+++ b/email-parser/Cargo.toml
@@ -36,6 +36,7 @@ compatibility-fixes = []
 content-disposition = ["mime"]
 unrecognized-headers = ["mime"]
 mime = ["textcode"]
+allow-duplicate-headers = []
 
 [dev-dependencies]
 email = "0.0.21"

--- a/email-parser/Cargo.toml
+++ b/email-parser/Cargo.toml
@@ -37,6 +37,7 @@ content-disposition = ["mime"]
 unrecognized-headers = ["mime"]
 mime = ["textcode"]
 allow-duplicate-headers = []
+decode-mime-body = []
 
 [dev-dependencies]
 email = "0.0.21"

--- a/email-parser/Cargo.toml
+++ b/email-parser/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["email", "mail", "mime", "parser"]
 
 [dependencies]
 textcode = {version="0.2", optional=true}
+timezone-abbreviations = { path = "../../timezone-abbreviations" }
 
 [features]
 default = ["headers"]

--- a/email-parser/src/email.rs
+++ b/email-parser/src/email.rs
@@ -269,11 +269,21 @@ impl<'a> Email<'a> {
                     .into_iter()
                     .collect(),
             )),
+            #[allow(unused_variables)]
             if let Some(body) = body {
-                Some(crate::parsing::mime::entity::decode_value(
-                    Cow::Borrowed(body),
-                    content_transfer_encoding.unwrap_or(ContentTransferEncoding::SevenBit),
-                )?)
+                #[cfg(feature = "decode-mime-body")]
+                {
+                    crate::parsing::mime::entity::decode_value(
+                        Cow::Borrowed(body),
+                        content_transfer_encoding.unwrap_or(ContentTransferEncoding::SevenBit),
+                    )
+                    .ok()
+                }
+
+                #[cfg(not(feature = "decode-mime-body"))]
+                {
+                    None
+                }
             } else {
                 None
             },

--- a/email-parser/src/email.rs
+++ b/email-parser/src/email.rs
@@ -176,11 +176,12 @@ impl<'a> Email<'a> {
                     }
                 }
                 #[cfg(feature = "to")]
-                Field::To(addresses) => {
-                    if to.is_none() {
-                        to = Some(addresses)
+                Field::To(mut addresses) => {
+                    if let Some(value) = to.as_mut() {
+                        let value: &mut Vec<Address> = value;
+                        value.append(&mut addresses);
                     } else {
-                        return Err(Error::DuplicateHeader("To"));
+                        to = Some(addresses)
                     }
                 }
                 #[cfg(feature = "cc")]

--- a/email-parser/src/email.rs
+++ b/email-parser/src/email.rs
@@ -312,7 +312,7 @@ impl<'a> Email<'a> {
         let sender = match sender {
             Some(sender) => sender,
             None => {
-                if from.len() == 1 {
+                if from.len() >= 1 {
                     from[0].clone()
                 } else {
                     return Err(Error::MissingHeader("Sender"));

--- a/email-parser/src/parsing/address.rs
+++ b/email-parser/src/parsing/address.rs
@@ -149,6 +149,8 @@ pub fn mailbox_list(input: &[u8]) -> Res<Vec<Mailbox>> {
         mailboxes.push(new_mailbox);
     }
 
+    let (input, _) = skip_whitespace(&input)?;
+
     Ok((input, mailboxes))
 }
 

--- a/email-parser/src/parsing/address.rs
+++ b/email-parser/src/parsing/address.rs
@@ -66,7 +66,12 @@ pub fn angle_addr(input: &[u8]) -> Res<EmailAddress> {
 }
 
 pub fn name_addr(input: &[u8]) -> Res<Mailbox> {
-    let (input, display_name) = optional(input, phrase);
+    let (input, display_name) = if let (input, Some(display_name)) = optional(input, in_quotes) {
+        (input, Some(display_name))
+    } else {
+        optional(input, phrase)
+    };
+
     let (input, angle_addr) = angle_addr(input)?;
 
     Ok((

--- a/email-parser/src/parsing/character_sets.rs
+++ b/email-parser/src/parsing/character_sets.rs
@@ -18,6 +18,11 @@ pub fn is_vchar(character: u8) -> bool {
 }
 
 #[inline]
+pub fn is_codepage_vchar(character: u8) -> bool {
+    character >= 0x21 && character <= 0xfe
+}
+
+#[inline]
 pub fn is_alpha(c: u8) -> bool {
     (c >= 0x41 && c <= 0x5a) || (c >= 0x61 && c <= 0x7a)
 }

--- a/email-parser/src/parsing/common.rs
+++ b/email-parser/src/parsing/common.rs
@@ -126,7 +126,6 @@ pub fn mime_unstructured(input: &[u8]) -> Res<Cow<str>> {
     let mut previous_was_encoded = false;
     let (mut input, output) = collect_many(input, |i| {
         let (i, mut wsp) = fws(i).unwrap_or((i, empty_string()));
-
         if let Ok((i, text)) = crate::parsing::mime::encoded_headers::encoded_word(i) {
             if previous_was_encoded {
                 return Ok((i, text));
@@ -135,7 +134,7 @@ pub fn mime_unstructured(input: &[u8]) -> Res<Cow<str>> {
                 add_string(&mut wsp, text);
                 return Ok((i, wsp));
             }
-        } else if let Ok((i, text)) = take_while1(i, is_vchar) {
+        } else if let Ok((i, text)) = take_while1(i, is_codepage_vchar) {
             previous_was_encoded = false;
             add_str(&mut wsp, text);
             return Ok((i, wsp));

--- a/email-parser/src/parsing/common.rs
+++ b/email-parser/src/parsing/common.rs
@@ -26,6 +26,14 @@ pub fn atom(mut input: &[u8]) -> Res<&str> {
     Ok((input, atom))
 }
 
+pub fn dot(input: &[u8]) -> Res<Cow<str>> {
+    if input.starts_with(b".") {
+        Ok((&input[1..], Cow::Borrowed(".")))
+    } else {
+        Err(Error::Unknown(". Required"))
+    }
+}
+
 pub fn dot_atom_text(input: &[u8]) -> Res<Cow<str>> {
     let (mut input, output) = take_while1(input, is_atext)?;
     let mut output = Cow::Borrowed(output);
@@ -86,6 +94,7 @@ pub fn phrase(input: &[u8]) -> Result<(&[u8], Vec<Cow<str>>), Error> {
                     crate::parsing::mime::encoded_headers::encoded_word(i)
                 }),
                 (|i| crate::parsing::common::word(i)),
+                (|i| crate::parsing::common::dot(i)),
             ][..],
         )
     }

--- a/email-parser/src/parsing/common.rs
+++ b/email-parser/src/parsing/common.rs
@@ -26,9 +26,14 @@ pub fn atom(mut input: &[u8]) -> Res<&str> {
     Ok((input, atom))
 }
 
-pub fn dot(input: &[u8]) -> Res<Cow<str>> {
-    if input.starts_with(b".") {
-        Ok((&input[1..], Cow::Borrowed(".")))
+pub fn address_chars(input: &[u8]) -> Res<Cow<str>> {
+    if input.starts_with(b".") || input.starts_with(b"@") {
+        unsafe {
+            Ok((
+                &input[1..],
+                Cow::Borrowed(std::str::from_utf8_unchecked(&input[0..1])),
+            ))
+        }
     } else {
         Err(Error::Unknown(". Required"))
     }
@@ -94,7 +99,7 @@ pub fn phrase(input: &[u8]) -> Result<(&[u8], Vec<Cow<str>>), Error> {
                     crate::parsing::mime::encoded_headers::encoded_word(i)
                 }),
                 (|i| crate::parsing::common::word(i)),
-                (|i| crate::parsing::common::dot(i)),
+                (|i| crate::parsing::common::address_chars(i)),
             ][..],
         )
     }

--- a/email-parser/src/parsing/common.rs
+++ b/email-parser/src/parsing/common.rs
@@ -88,6 +88,16 @@ pub fn word(input: &[u8]) -> Res<Cow<str>> {
     )
 }
 
+pub fn in_quotes(input: &[u8]) -> Result<(&[u8], Vec<Cow<str>>), Error> {
+    let (input, _) = fws(input)?;
+    if !input.starts_with(b"\"") {
+        return Err(Error::Unknown("Has to start with \""));
+    }
+    let (input, value) = take_while(&input[1..], |c| c != '"' as u8)?;
+    let (input, _) = fws(&input[1..])?;
+    Ok((&input, vec![Cow::Borrowed(value)]))
+}
+
 pub fn phrase(input: &[u8]) -> Result<(&[u8], Vec<Cow<str>>), Error> {
     #[cfg(feature = "mime")]
     fn word(input: &[u8]) -> Res<Cow<str>> {

--- a/email-parser/src/parsing/fields.rs
+++ b/email-parser/src/parsing/fields.rs
@@ -587,6 +587,17 @@ pub fn trace(
 }
 
 pub fn unknown(input: &[u8]) -> Res<(&str, Cow<str>)> {
+    // A header should never begin with whitespace, but here we are.
+    // We add this to make the parsing more resilient. Supporting:
+    // `    NameOfHeader: ValueOfHeader`
+
+    let input = if input.len() > 0 && input[0].is_ascii_whitespace() {
+        let (new_input, _) = skip_whitespace(input)?;
+        new_input
+    } else {
+        input
+    };
+
     let (input, name) = take_while1(input, is_ftext)?;
     let (input, ()) = tag(
         input,

--- a/email-parser/src/parsing/fields.rs
+++ b/email-parser/src/parsing/fields.rs
@@ -594,7 +594,7 @@ pub fn unknown(input: &[u8]) -> Res<(&str, Cow<str>)> {
         "TAG ERROR: A header name must be followed by a `:`.",
     )?;
     #[cfg(not(feature = "unrecognized-headers"))]
-    let (input, value) = unstructured(input)?;
+    let (input, value) = unstructured_until_linebreak(input)?;
     #[cfg(feature = "unrecognized-headers")]
     let (input, value) = mime_unstructured(input)?;
 

--- a/email-parser/src/parsing/fields.rs
+++ b/email-parser/src/parsing/fields.rs
@@ -175,9 +175,8 @@ pub fn date(input: &[u8]) -> Res<DateTime> {
         "TAG NO CASE ERROR: Header name (Date) does not match.",
     )?;
     let (input, date_time) = date_time(input)?;
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`Date` in this case) must end with a CRLF sequence.",
     )?;
 
@@ -192,9 +191,8 @@ pub fn from(input: &[u8]) -> Res<Vec<Mailbox>> {
         "TAG NO CASE ERROR: Header name (From) does not match.",
     )?;
     let (input, mailbox_list) = mailbox_list(input)?;
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`From` in this case) must end with a CRLF sequence.",
     )?;
 
@@ -209,9 +207,8 @@ pub fn sender(input: &[u8]) -> Res<Mailbox> {
         "TAG NO CASE ERROR: Header name (Sender) does not match.",
     )?;
     let (input, mailbox) = mailbox(input)?;
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`Sender` in this case) must end with a CRLF sequence.",
     )?;
 
@@ -226,9 +223,8 @@ pub fn reply_to(input: &[u8]) -> Res<Vec<Address>> {
         "TAG NO CASE ERROR: Header name (Reply-To) does not match.",
     )?;
     let (input, mailbox) = address_list(input)?;
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`Reply-To` in this case) must end with a CRLF sequence.",
     )?;
 
@@ -243,9 +239,8 @@ pub fn to(input: &[u8]) -> Res<Vec<Address>> {
         "TAG NO CASE ERROR: Header name (To) does not match.",
     )?;
     let (input, mailbox) = address_list(input)?;
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`To` in this case) must end with a CRLF sequence.",
     )?;
 
@@ -260,9 +255,8 @@ pub fn cc(input: &[u8]) -> Res<Vec<Address>> {
         "TAG NO CASE ERROR: Header name (Cc) does not match.",
     )?;
     let (input, mailbox) = address_list(input)?;
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`Cc` in this case) must end with a CRLF sequence.",
     )?;
 
@@ -283,9 +277,8 @@ pub fn bcc(input: &[u8]) -> Res<Vec<Address>> {
     } else {
         return Err(Error::Unknown("Invalid bcc field"));
     };
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`Bcc` in this case) must end with a CRLF sequence.",
     )?;
 
@@ -300,9 +293,8 @@ pub fn message_id(input: &[u8]) -> Res<(Cow<str>, Cow<str>)> {
         "TAG NO CASE ERROR: Header name (Message-ID) does not match.",
     )?;
     let (input, id) = crate::parsing::address::message_id(input)?;
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`Message-ID` in this case) must end with a CRLF sequence.",
     )?;
 
@@ -317,9 +309,8 @@ pub fn in_reply_to(input: &[u8]) -> Res<Vec<(Cow<str>, Cow<str>)>> {
         "TAG NO CASE ERROR: Header name (Reply-To) does not match.",
     )?;
     let (input, ids) = many1(input, crate::parsing::address::message_id)?;
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`In-Reply-To` in this case) must end with a CRLF sequence.",
     )?;
 
@@ -334,9 +325,8 @@ pub fn references(input: &[u8]) -> Res<Vec<(Cow<str>, Cow<str>)>> {
         "TAG NO CASE ERROR: Header name (References) does not match.",
     )?;
     let (input, ids) = many1(input, crate::parsing::address::message_id)?;
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`References` in this case) must end with a CRLF sequence.",
     )?;
 
@@ -354,9 +344,8 @@ pub fn subject(input: &[u8]) -> Res<Cow<str>> {
     let (input, subject) = unstructured(input)?;
     #[cfg(feature = "mime")]
     let (input, subject) = mime_unstructured(input)?;
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`Subject` in this case) must end with a CRLF sequence.",
     )?;
 
@@ -374,9 +363,8 @@ pub fn comments(input: &[u8]) -> Res<Cow<str>> {
     let (input, comments) = unstructured(input)?;
     #[cfg(feature = "mime")]
     let (input, comments) = mime_unstructured(input)?;
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`Comments` in this case) must end with a CRLF sequence.",
     )?;
 
@@ -400,9 +388,8 @@ pub fn keywords(input: &[u8]) -> Res<Vec<Vec<Cow<str>>>> {
         keywords.push(new_keyword);
     }
 
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`Keywords` in this case) must end with a CRLF sequence.",
     )?;
 
@@ -518,9 +505,8 @@ pub fn return_path(input: &[u8]) -> Res<Option<EmailAddress>> {
                 as fn(input: &[u8]) -> Res<Option<EmailAddress>>,
         ][..],
     )?;
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`Return-Path` in this case) must end with a CRLF sequence.",
     )?;
 
@@ -565,9 +551,8 @@ pub fn received(input: &[u8]) -> Res<(Vec<ReceivedToken>, DateTime)> {
         "TAG ERROR: Received tokens must be followed by a `;`.",
     )?;
     let (input, date_time) = date_time(input)?;
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`Received` in this case) must end with a CRLF sequence.",
     )?;
 
@@ -609,11 +594,7 @@ pub fn unknown(input: &[u8]) -> Res<(&str, Cow<str>)> {
     #[cfg(feature = "unrecognized-headers")]
     let (input, value) = mime_unstructured(input)?;
 
-    let (input, ()) = tag(
-        input,
-        b"\r\n",
-        "TAG ERROR: A header must end with a CRLF sequence.",
-    )?;
+    let (input, ()) = newline(input, "TAG ERROR: A header must end with a CRLF sequence.")?;
 
     Ok((input, (name, value)))
 }

--- a/email-parser/src/parsing/message.rs
+++ b/email-parser/src/parsing/message.rs
@@ -42,18 +42,16 @@ pub fn body_lines(input: &[u8]) -> Result<Vec<Cow<str>>, Error> {
     if input.is_empty() {
         return Ok(Vec::new());
     }
-    let (mut input, ()) = tag(
+    let (mut input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: Headers must be followed by a CRLF sequence.",
     )?;
 
     let mut lines = Vec::new();
     loop {
         let (new_input, new_line) = line(input)?;
-        match tag(
+        match newline(
             new_input,
-            b"\r\n",
             "TAG ERROR: In a body, a line must end with a CRLF sequence.",
         ) {
             Ok((new_input, ())) => input = new_input,
@@ -77,17 +75,15 @@ pub fn body(input: &[u8]) -> Result<Option<Cow<str>>, Error> {
         return Ok(None);
     }
 
-    let (mut new_input, ()) = tag(
+    let (mut new_input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: Headers must be followed by a CRLF sequence.",
     )?;
 
     loop {
         let (new_input2, ()) = check_line(new_input)?;
-        match tag(
+        match newline(
             new_input2,
-            b"\r\n",
             "TAG ERROR: In a body, a line must end with a CRLF sequence.",
         ) {
             Ok((new_input2, ())) => new_input = new_input2,
@@ -123,11 +119,7 @@ pub fn parse_message(input: &[u8]) -> Result<(Vec<Field>, Option<&[u8]>), Error>
         return Ok((fields, None));
     }
 
-    let (new_input, ()) = tag(
-        input,
-        b"\r\n",
-        "TAG ERROR: Headers must be followed by a CRLF sequence.",
-    )?;
+    let (new_input, ()) = newline(input, "TAG ERROR: Headers must be followed by a CRLF")?;
 
     Ok((fields, Some(new_input)))
 }

--- a/email-parser/src/parsing/mime/entity.rs
+++ b/email-parser/src/parsing/mime/entity.rs
@@ -214,9 +214,8 @@ pub fn header_part(
         ));
     }
 
-    let (input, _) = tag(
+    let (input, _) = newline(
         &input,
-        b"\r\n",
         "TAG ERROR: A MIME entity header part must be followed by a CRLF sequence.",
     )?;
 

--- a/email-parser/src/parsing/mime/entity.rs
+++ b/email-parser/src/parsing/mime/entity.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use super::multipart;
 
 pub fn raw_entity(mut input: Cow<[u8]>) -> Result<RawEntity, Error> {
+    #[allow(unused)]
     let (
         encoding,
         mime_type,
@@ -34,6 +35,7 @@ pub fn raw_entity(mut input: Cow<[u8]>) -> Result<RawEntity, Error> {
         description,
         id,
         parameters,
+        #[cfg(feature = "content-disposition")]
         disposition,
         value,
         additional_headers,

--- a/email-parser/src/parsing/mime/mime_fields.rs
+++ b/email-parser/src/parsing/mime/mime_fields.rs
@@ -55,9 +55,8 @@ pub fn mime_version(input: &[u8]) -> Res<(u8, u8)> {
     let (input, d2) = u8_number(input)?;
 
     let (input, _cwfs) = ignore_inline_cfws(input)?;
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`MIME-Version` in this case) must end with a CRLF sequence.",
     )?;
 
@@ -235,9 +234,8 @@ pub fn content_type(input: &[u8]) -> Res<(ContentType, Cow<str>, HashMap<Cow<str
     let parameters = super::percent_encoding::collect_parameters(parameters_vec)?;
 
     let (input, ()) = ignore_inline_cfws(input)?;
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`Content-Type` in this case) must end with a CRLF sequence.",
     )?;
 
@@ -349,9 +347,8 @@ pub fn content_disposition(input: &[u8]) -> Res<Disposition> {
     disposition.unstructured = super::percent_encoding::collect_parameters(parameters_vec)?;
 
     let (input, ()) = ignore_inline_cfws(input)?;
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`Content-Disposition` in this case) must end with a CRLF sequence.",
     )?;
 
@@ -400,7 +397,7 @@ pub fn content_transfer_encoding(input: &[u8]) -> Res<ContentTransferEncoding> {
     )?;
 
     let (input, _cwfs) = ignore_inline_cfws(input)?;
-    let (input, ()) = tag(input, b"\r\n", "TAG ERROR: A header (`Content-Transfer-Encoding` in this case) must end with a CRLF sequence.")?;
+    let (input, ()) = newline(input, "TAG ERROR: A header (`Content-Transfer-Encoding` in this case) must end with a CRLF sequence.")?;
 
     Ok((input, encoding))
 }
@@ -413,9 +410,8 @@ pub fn content_id(input: &[u8]) -> Res<(Cow<str>, Cow<str>)> {
         "TAG NO CASE ERROR: Header name (Content-ID) does not match.",
     )?;
     let (input, id) = crate::parsing::address::message_id(input)?;
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`Content-ID` in this case) must end with a CRLF sequence.",
     )?;
 
@@ -430,9 +426,8 @@ pub fn content_description(input: &[u8]) -> Res<Cow<str>> {
         "TAG NO CASE ERROR: Header name (Content-Description) does not match.",
     )?;
     let (input, description) = mime_unstructured(input)?;
-    let (input, ()) = tag(
+    let (input, ()) = newline(
         input,
-        b"\r\n",
         "TAG ERROR: A header (`Content-Description` in this case) must end with a CRLF sequence.",
     )?;
 

--- a/email-parser/src/parsing/time.rs
+++ b/email-parser/src/parsing/time.rs
@@ -63,7 +63,15 @@ pub fn year(input: &[u8]) -> Res<usize> {
 
     let (input, year) =
         take_while1(input, is_digit).map_err(|_e| Error::Unknown("no digit in year"))?;
-    if year.len() < 4 {
+
+    // Some emails have year only as 10 (for 2010)
+    if year.len() == 2 {
+        let year: usize = year
+            .parse()
+            .map_err(|_e| Error::Unknown("Failed to parse year"))?;
+        let (input, _) = fws(input)?;
+        return Ok((input, 2000 + year));
+    } else if year.len() < 4 {
         return Err(Error::Unknown("year is expected to have 4 digits or more"));
     }
     let year: usize = year

--- a/email-parser/src/parsing/time.rs
+++ b/email-parser/src/parsing/time.rs
@@ -95,7 +95,12 @@ pub fn day(input: &[u8]) -> Res<u8> {
 }
 
 pub fn time_of_day(input: &[u8]) -> Res<Time> {
-    let (input, hour) = two_digits(input)?;
+    let (input, hour) = match digit(input) {
+        // Support `9:23:23` time format
+        Ok((new_input, digit)) if new_input.starts_with(b":") => (new_input, digit),
+        // Support `09:23:23` time format
+        _ => two_digits(input)?,
+    };
     if hour > 23 {
         return Err(Error::Unknown("There is only 24 hours in a day"));
     }

--- a/email-parser/src/parsing/time.rs
+++ b/email-parser/src/parsing/time.rs
@@ -199,6 +199,16 @@ pub fn zone(input: &[u8]) -> Res<Zone> {
         return Err(Error::Unknown("zone minute_offset out of range"));
     }
 
+    // Some emails move the name of the timezone at the end of the date header
+    let (_, comment) = take_while(&input, |c| {
+        c != '\r' as u8 && c != '\n' as u8 && c != '"' as u8
+    })?;
+    let input = if comment.is_empty() {
+        input
+    } else {
+        &input[comment.len()..]
+    };
+
     Ok((
         input,
         Zone {

--- a/email-parser/src/parsing/time.rs
+++ b/email-parser/src/parsing/time.rs
@@ -187,7 +187,13 @@ pub fn zone(input: &[u8]) -> Res<Zone> {
     input = &input[1..];
 
     let (input, hour_offset) = two_digits(input)?;
-    let (input, minute_offset) = two_digits(input)?;
+
+    // Some mails have a "00:00" timezone
+    let (input, minute_offset) = if input.starts_with(b":") {
+        two_digits(&input[1..])?
+    } else {
+        two_digits(input)?
+    };
 
     if minute_offset > 59 {
         return Err(Error::Unknown("zone minute_offset out of range"));

--- a/email-parser/src/parsing/whitespaces.rs
+++ b/email-parser/src/parsing/whitespaces.rs
@@ -8,10 +8,9 @@ pub fn fws(input: &[u8]) -> Res<Cow<str>> {
             input,
             |input| take_while(input, is_wsp),
             |input| {
-                tag(
+                newline(
                     input,
-                    b"\r\n",
-                    "TAG ERROR: A folding whitespace must end with a `\\r\\n` sequence.",
+                    "TAG ERROR: A folding whitespace must end with a `\r\n` sequence.",
                 )
             },
         )

--- a/email-parser/src/parsing/whitespaces.rs
+++ b/email-parser/src/parsing/whitespaces.rs
@@ -28,6 +28,12 @@ pub fn fws(input: &[u8]) -> Res<Cow<str>> {
 }
 
 #[inline]
+pub fn skip_whitespace(input: &[u8]) -> Res<()> {
+    let (input, _) = take_while(&input, is_wsp)?;
+    Ok((input, ()))
+}
+
+#[inline]
 pub fn ccontent(input: &[u8]) -> Res<Cow<str>> {
     match_parsers(
         input,

--- a/email-parser/src/time.rs
+++ b/email-parser/src/time.rs
@@ -52,6 +52,25 @@ pub struct Date {
     pub year: usize,
 }
 
+impl Date {
+    pub fn month_number(&self) -> u8 {
+        match self.month {
+            Month::January => 1,
+            Month::February => 2,
+            Month::March => 3,
+            Month::April => 4,
+            Month::May => 5,
+            Month::June => 6,
+            Month::July => 7,
+            Month::August => 8,
+            Month::September => 9,
+            Month::October => 10,
+            Month::November => 11,
+            Month::December => 12,
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct DateTime {
     pub day_name: Option<Day>,

--- a/email-parser/tests/local_emails.rs
+++ b/email-parser/tests/local_emails.rs
@@ -40,8 +40,124 @@ fn enron() {
     println!("{}/{}", ok, tot)
 }
 
-#[cfg(feature = "mime")]
 #[test]
+fn test_date_timezone_abbr() {
+    // Test timezone abbreviations
+    assert_success("Date", "Tue, 01 Nov 2016 00:19:05 GMT");
+}
+
+#[test]
+fn test_date_singular_hour() {
+    // Test singular hours
+    assert_success("Date", "Thu, 3 Dec 2020 9:20:16 +0100");
+}
+
+#[test]
+fn test_subject_latin1() {
+    #[cfg(feature = "mime")]
+    {
+        // Test Latin-1 chars in subject
+        assert_success("Subject", "Neuer, privater Eintrag fьr dich");
+    }
+}
+
+#[test]
+fn test_display_name_dot() {
+    #[cfg(feature = "mime")]
+    {
+        // Test '.' in Subject display name
+        assert_success("From", "Example.com <webmaster@example.com>");
+    }
+}
+
+#[test]
+fn test_display_name_at() {
+    #[cfg(feature = "mime")]
+    {
+        // Test '@' in Subject display name
+        assert_success("From", "bb.b@exxx.de <bb.b@exxx.de>");
+    }
+}
+
+#[test]
+fn test_date_two_digits_year() {
+    // Test support for a year with only two digits
+    assert_success("Date", "Wed, 15 Sep 10 13:53:08 +0200");
+}
+
+#[test]
+fn test_display_name_unicode() {
+    // Test support unicode in display name
+    assert_success("From", "\"Hey M端n look!\" <noreply@example.com>");
+}
+
+#[test]
+fn test_timezone_colon() {
+    // Test support for a timezone with the '+00:00' format
+    assert_success("Date", "Fri, 04 Aug 2006 11:52:00 +00:00");
+}
+
+#[test]
+fn test_timezone_meta() {
+    // Test support for a timezone with the additional meta info at the end
+    assert_success(
+        "Date",
+        "Thu, 31 Aug 2006 22:03:40 +0200 (Westeuropäische Sommerzeit)",
+    );
+}
+
+#[test]
+fn test_angle_right_whitespace() {
+    // Test support for additional whitespace after the angle bracket at the end
+    assert_success("From", "\"Ryan Riddle\" <hello@forrst.com> ");
+}
+
+#[test]
+fn test_random_unicode() {
+    // If you check a hex editor, you'll find unicode chars in the Feedback-ID line at the end
+    assert_success("Feedback-ID", "Feedback-ID: 15bbe728-699d-4fab-9ed5-2551c7f2fd70:b4cad6e3-63d4-4776-bd51-33e0d8fe639a:email:epslh1 ");
+}
+
+#[test]
+fn test_normal_email_works() {
+    assert_success("To", "author@gmail.com");
+}
+
+/// Generate a fake email with valid information except for the
+/// invalid information added via the override flags
+fn assert_success(override_key: &str, override_value: &str) {
+    let keys = &[
+        ("Delivered-To", "example@example.com"),
+        ("To", "example@example.com"),
+        ("From", "from@example.com"),
+        ("Sender", "sender@example.com"),
+        ("Date", "Thu, 3 Dec 2020 9:20:16 +0100"),
+        ("Content-Type", "text/plain; charset=\"utf-8\""),
+        (
+            "Message-ID",
+            "<aaacddda-4848-8888-9999-39652ca9c15c@aaa2a01c9u286.aa.local>",
+        ),
+        ("Subject", "Hello World"),
+        ("Content-Transfer-Encoding", "7bit"),
+        ("Feedback-ID", "klasjdfkladsfjkladsjfkl"),
+    ];
+    let headers: Vec<String> = keys
+        .iter()
+        .map(|(key, value)| {
+            if key == &override_key {
+                format!("{}: {}", override_key, override_value)
+            } else {
+                format!("{}: {}", key, value)
+            }
+        })
+        .collect();
+    let joined = headers.join("\r\n");
+    let message = format!("{}\r\n\r\nBody", &joined);
+    let email = Email::parse(&message.as_bytes());
+    assert_eq!(email.err(), None)
+}
+
+#[cfg(feature = "mime")]
 fn my_emails() {
     let mut ok = 0;
     let mut tot = 0;


### PR DESCRIPTION
Hey! I recently ran `email-parser` on a batch of ~650.000 emails from 2004 - 2021. Initially roughly half of those emails were marked as invalid. I slowly went through the issues and fixed one after the other in order to be able to parse as many emails a possible. All the changes can be found in this PR.
For me, it was important that I'm able to parse the majority of my mails. With these changes, all mails except for ~100 are parsed properly (and those are broken beyond repair, I had a brief look). However, I'm not sure if all of my changes are sensible additions. I added one commit for each fix so that you can easily figure out which ones are interesting. I also added tests (in the last commit) that involve most of the fixed issues.

Finally, I've added two feature flags in order to improve parsing:

- `allow-duplicate-headers`: Gmail seems to add multiple `To` fields if forwarding from one Gmail account to another. Similarly, I had many emails with multiple `Message-ID` fields and so on. I've encapsulated this into a flag. If active, multiple headers are allowed, and in case the value is a list of items (e.g. `Reply-To`) they're all merged together. If inactive, the previous behavior of not allowing multiple headers stays as before.
- `decode-mime-body`: I do need mime support for the parsing of `Subject` fields, but I'm not interested in bodies. Given that parsing of bodies might be expensive, I added a flag to specifically disable the parsing of bodies if mime is active.

I also added one dependency. This could also be made into a feature flag I guess. This library converts timezone abbreviations (such as `GMT`) to proper timezone information. I build that yesterday for the specific purpose of parsing timezone information in `email-parser`.

Cheers & Thanks for this nice library!