### PR TITLE
make take_while function unsafe

### DIFF
--- a/email-parser/src/parsing/address.rs
+++ b/email-parser/src/parsing/address.rs
@@ -9,7 +9,7 @@ pub fn message_id(input: &[u8]) -> Res<(Cow<str>, Cow<str>)> {
             b"[",
             "TAG ERROR: In message_id, a no_fold_litteral domain must be preceded by a `[`.",
         )?;
-        let (input, domain) = take_while(input, is_dtext)?;
+        let (input, domain) = unsafe { take_while(input, is_dtext)? };
         let (input, ()) = tag(
             input,
             b"]",

--- a/email-parser/src/parsing/combinators.rs
+++ b/email-parser/src/parsing/combinators.rs
@@ -82,7 +82,7 @@ where
 }
 
 #[inline]
-pub fn take_while<F>(input: &[u8], mut condition: F) -> Res<&str>
+pub unsafe fn take_while<F>(input: &[u8], mut condition: F) -> Res<&str>
 where
     F: FnMut(u8) -> bool,
 {
@@ -282,8 +282,8 @@ mod tests {
 
     #[test]
     fn test_take_while() {
-        assert_eq!(take_while(b"     abc", is_wsp).unwrap().1.len(), 5);
-        assert_eq!(take_while(b"abc", is_wsp).unwrap().1.len(), 0);
+        assert_eq!(unsafe {take_while(b"     abc", is_wsp).unwrap().1.len()}, 5);
+        assert_eq!(unsafe {take_while(b"abc", is_wsp).unwrap().1.len()}, 0);
     }
 
     #[test]

--- a/email-parser/src/parsing/common.rs
+++ b/email-parser/src/parsing/common.rs
@@ -33,7 +33,7 @@ pub fn dot_atom_text(input: &[u8]) -> Res<Cow<str>> {
     loop {
         if input.starts_with(b".") {
             if let Ok((new_input, atom)) = if cfg!(feature = "compatibility-fixes") {
-                take_while(&input[1..], is_atext)
+                unsafe { take_while(&input[1..], is_atext) }
             } else {
                 take_while1(&input[1..], is_atext)
             } {

--- a/email-parser/src/parsing/whitespaces.rs
+++ b/email-parser/src/parsing/whitespaces.rs
@@ -6,7 +6,7 @@ pub fn fws(input: &[u8]) -> Res<Cow<str>> {
     let (input, before) = optional(input, |input| {
         pair(
             input,
-            |input| take_while(input, is_wsp),
+            |input| unsafe { take_while(input, is_wsp) },
             |input| {
                 tag(
                     input,


### PR DESCRIPTION
Hello, I found a soundness issue in this crate.
https://github.com/Mubelotix/email-parser/blob/0e72550027a2dfe53c818f44fa855cf26bc88f31/email-parser/src/parsing/combinators.rs#L85-L100
The unsafe function called needs to ensure that the parameter must be:

- The bytes passed in must be valid UTF-8.
[https://doc.rust-lang.org/std/str/fn.from_utf8_unchecked.html](url)
When the parameter condition panics, the input will be saved as non-utf8, which may cause undefined behavior in multi-threaded programs. The developer who calls the take_while function may not notice this safety requirement.
Marking them unsafe also means that callers must make sure they know what they're doing.